### PR TITLE
Fix github key issue

### DIFF
--- a/devstack.yaml
+++ b/devstack.yaml
@@ -3,7 +3,7 @@
   vars:
     devstack_repo: git://github.com/openstack-dev/devstack.git
     public_ip: 192.168.27.100
-    version: stable/havana
+    version: stable/icehouse
     neutron: True
     swift: True
     security_groups: False
@@ -26,7 +26,8 @@
       sudo: True
 
     - name: checkout devstack
-      git: "repo={{ devstack_repo }} dest=/home/vagrant/devstack version={{ version }}"
+      git: "repo={{ devstack_repo }} dest=/home/vagrant/devstack version={{ version }} accept_hostkey=yes"
+        
 
     - name: local.conf
       template: src=templates/local.conf.j2 dest=/home/vagrant/devstack/local.conf
@@ -36,5 +37,9 @@
 
     - name: enable eth2
       command: ip link set dev eth2 up
+      sudo: True
+  
+    - name: install English langpack
+      apt: "name=language-pack-en update_cache=yes"
       sudo: True
 


### PR DESCRIPTION
Added github key to enable git clone of devstack.

  * Added output of "ssh-keyscan github" to files/github-known-host
  * Added copying of above key into target VM
  * Added install of English langpack to resolve failure of neutron
      commands.
  * Bumped to Icehouse